### PR TITLE
fix typos, link to lit readme file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,14 +1,29 @@
 # Hexes
 
-This is a simple game that uses a luvit server to sync up piece movements between all players.
+This is a simple game that run above a luvi http server and WebSocket to sync up piece movements between all players.
 
 ## Get it!
 
-All you need is lit installed on your system.  You then downlaod and build this using:
+All you need is [lit](https://github.com/luvit/lit#installing-lit) installed on your system . 
+
+You then download and build this using:
 
     lit make lit://creationix/hexes
+    
+This will build an executable in your current directory
+    
+##Run it!
 
-This will build an executible in your current directory.  Run it with either `./hexes` on unix systems or `hexes.exe` on windows.
+###unix
+
+```bash
+    ./hexes
+```
+###windows
+    
+```PowerShell
+    hexes.exe
+```
 
 ## Running as Luvit Script
 


### PR DESCRIPTION
tested it with Luvit failed:

```
$: luvit main.lua 
HTTP server listening at http://0.0.0.0:8080/
[string "/home/lionel/dev/lua/luvit/app/hexes/deps/web..."]:33: ENOENT: no such file or directory: /index.html
```

step to reproduce:
`git clone https://github.com/creationix/hexes.git`
`lit install`
`luvit main.lua`
GET http://127.0.0.1:8080

my env:

```
luvit version: 2.2.0
luvi version: v2.1.1
```

running as a luvi app is fine
